### PR TITLE
Fix codegen, and regenerating atrium-api

### DIFF
--- a/atrium-api/src/com/atproto/server/describe_server.rs
+++ b/atrium-api/src/com/atproto/server/describe_server.rs
@@ -5,6 +5,9 @@
 pub struct Output {
     ///List of domain suffixes that can be used in account handles.
     pub available_user_domains: Vec<String>,
+    ///Contact information
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact: Option<Contact>,
     pub did: crate::types::string::Did,
     ///If true, an invite code must be supplied to create an account on this instance.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -19,6 +22,12 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Contact {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Links {

--- a/lexicon/atrium-codegen/src/token_stream.rs
+++ b/lexicon/atrium-codegen/src/token_stream.rs
@@ -294,9 +294,17 @@ fn lex_object_property(
         }
     );
     let mut attributes = match property {
-        LexObjectProperty::Bytes(_) => quote! {
-            #[serde(with = "serde_bytes")]
-        },
+        LexObjectProperty::Bytes(_) => {
+            let default = if is_required {
+                quote!()
+            } else {
+                quote!(#[serde(default)])
+            };
+            quote! {
+                #default
+                #[serde(with = "serde_bytes")]
+            }
+        }
         _ => quote!(),
     };
     if !is_required {


### PR DESCRIPTION
With this fix, `codegen` adds `#[serde(default)]` to optional `bytes` properties to be the same as your dirty modification.
And including lexicon changes: https://github.com/bluesky-social/atproto/commit/722d4173eeb9b2d3adb24e74546357909b6458a2#diff-318cab49d4b6456e70c91f73cf5191117e4329e6bbfca101f5df2824e835fd69